### PR TITLE
Add Contacts::Contact & Contacts::Automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ test_steps: &test_steps
       - active_campaign_rb-ruby-{{ .Environment.CIRCLE_JOB }}-
 
   # Bundle install dependencies
+  - run: gem uninstall bundler
+  - run: gem install bundler -v 2.0.1
   - run: bundle install --path vendor/bundle
 
   # Cache Dependencies

--- a/active_campaign.gemspec
+++ b/active_campaign.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '~> 2.0.1'
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/active_campaign/v3/client.rb
+++ b/lib/active_campaign/v3/client.rb
@@ -1,5 +1,6 @@
 require 'httparty'
 require 'active_campaign/parse_json'
+require 'active_campaign/v3/clients/contacts/contact'
 require 'active_campaign/v3/clients/deals/deal'
 require 'active_campaign/v3/clients/deals/deal_stage'
 require 'active_campaign/v3/clients/deals/deal_task'
@@ -14,6 +15,7 @@ module ActiveCampaign
     class Client
       include HTTParty
       include ActiveCampaign::ParseJson
+      include ActiveCampaign::V3::Clients::Contacts::Contact
       include ActiveCampaign::V3::Clients::Deals::Deal
       include ActiveCampaign::V3::Clients::Deals::DealStage
       include ActiveCampaign::V3::Clients::Deals::DealTask

--- a/lib/active_campaign/v3/client.rb
+++ b/lib/active_campaign/v3/client.rb
@@ -1,5 +1,6 @@
 require 'httparty'
 require 'active_campaign/parse_json'
+require 'active_campaign/v3/clients/contacts/automation'
 require 'active_campaign/v3/clients/contacts/contact'
 require 'active_campaign/v3/clients/deals/deal'
 require 'active_campaign/v3/clients/deals/deal_stage'
@@ -15,6 +16,7 @@ module ActiveCampaign
     class Client
       include HTTParty
       include ActiveCampaign::ParseJson
+      include ActiveCampaign::V3::Clients::Contacts::Automation
       include ActiveCampaign::V3::Clients::Contacts::Contact
       include ActiveCampaign::V3::Clients::Deals::Deal
       include ActiveCampaign::V3::Clients::Deals::DealStage

--- a/lib/active_campaign/v3/clients/contacts/automation.rb
+++ b/lib/active_campaign/v3/clients/contacts/automation.rb
@@ -1,0 +1,41 @@
+module ActiveCampaign
+  module V3
+    module Clients
+      module Contacts
+        module Automation
+          def contact_automation_create(contact_id:, automation_id:)
+            param_types = {
+              body: [
+                :contact,
+                :automation,
+              ],
+            }
+
+            post(
+              '/contactAutomations',
+              { contact: contact_id, automation: automation_id },
+              param_types,
+              :contactAutomation
+            )
+          end
+
+          def contact_automation_retrieve(id:)
+            param_types = { path: :id }
+
+            get('/contactAutomations/:id', { id: id }, param_types)
+          end
+
+          def contact_automation_delete(id:)
+            param_types = { path: :id }
+
+            delete('/contactAutomations/:id', { id: id }, param_types)
+          end
+
+          def contact_automation_list
+            get('/contactAutomations')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_campaign/v3/clients/contacts/contact.rb
+++ b/lib/active_campaign/v3/clients/contacts/contact.rb
@@ -1,0 +1,148 @@
+module ActiveCampaign
+  module V3
+    module Clients
+      module Contacts
+        module Contact
+          def contact_create(email:, **args)
+            param_types = {
+              body: [
+                :email,
+                :firstName,
+                :lastName,
+                :deleted,
+                :orgid,
+                :phone,
+              ],
+            }
+
+            post('/contacts', args.merge(email: email), param_types, :contact)
+          end
+
+          def contact_sync(email:, **args)
+            param_types = {
+              body: [
+                :email,
+                :firstName,
+                :lastName,
+                :deleted,
+                :orgid,
+                :phone,
+              ],
+            }
+
+            post('/contact/sync', args.merge(email: email), param_types, :contact)
+          end
+
+          def contact_retrieve(id:)
+            param_types = { path: :id }
+
+            get('/contacts/:id', { id: id }, param_types)
+          end
+
+          def contact_subscribe_to_list(contact_id:, list_id:)
+            param_types = {
+              body: [
+                :contact,
+                :list,
+                :status,
+              ],
+            }
+
+            post(
+              '/contactLists',
+              { contact: contact_id, list: list_id, status: 1 },
+              param_types,
+              :contactList
+            )
+          end
+
+          def contact_unsubscribe_from_list(contact_id:, list_id:)
+            param_types = {
+              body: [
+                :contact,
+                :list,
+                :status,
+              ],
+            }
+
+            post(
+              '/contactLists',
+              { contact: contact_id, list: list_id, status: 2 },
+              param_types,
+              :contactList
+            )
+          end
+
+          def contact_update(id:, **args)
+            param_types = {
+              path: :id,
+              body: [
+                :email,
+                :firstName,
+                :lastName,
+                :deleted,
+                :orgid,
+                :phone,
+              ],
+            }
+
+            put('/contacts/:id', args.merge(id: id), param_types, :contact)
+          end
+
+          def contact_delete(id:)
+            param_types = { path: :id }
+
+            delete('/contacts/:id', { id: id }, param_types)
+          end
+
+          def contact_list(**args)
+            param_types = {
+              query: [
+                :ids,
+                :datetime,
+                :email,
+                :email_like,
+                :exclude,
+                :fields,
+                :formid,
+                :id_greater,
+                :id_less,
+                :listid,
+                :organization,
+                :search,
+                :segmentid,
+                :seriesid,
+                :status,
+                :tagid,
+                :created_before,
+                :created_after,
+                :updated_before,
+                :updated_after,
+                :waitid,
+                'orders[cdate]',
+                'orders[email]',
+                'orders[first_name]',
+                'orders[last_name]',
+                'orders[name]',
+                'orders[score]',
+                'in_group_lists',
+              ]
+            }
+
+            get('/contacts', args, param_types)
+          end
+
+          def contact_list_automations(id:)
+            param_types = {
+              path: [
+                :id,
+              ]
+            }
+
+            get('/contacts/:id/contactAutomations', { id: id }, param_types)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- The main purpose of this was to add the ability to add a Contact to an
Automation. While I was at it, I built out all of the Contact::Automation
wrapper. I also built out all of the V3 Contacts::Contact wrapper as that's
where the ability to list Automations that a particular Contact is in lives.