### PR TITLE
Update dry-configurable Version to Prepare for Ruby 2.7

### DIFF
--- a/active_campaign.gemspec
+++ b/active_campaign.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.4', '>= 3.4.2'
 
   spec.add_dependency 'httparty', '~> 0.16.2'
-  spec.add_dependency 'dry-configurable', '~> 0.7.0'
+  spec.add_dependency 'dry-configurable', '~> 0.12.0'
   spec.add_dependency 'hashie', '~> 3.5', '>= 3.5.7'
 end


### PR DESCRIPTION
In the goal of upgrading crashdown to ruby to 2.7.1, this is a dependency that is used that needs to update.